### PR TITLE
Add favicon to calendar page

### DIFF
--- a/jofun2/calendar/index.html
+++ b/jofun2/calendar/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Calendario Jofun2</title>
+  <link rel="icon" href="faviconn.png" />
   <style>
     :root {
       --bg: #f4f6fb;


### PR DESCRIPTION
## Summary
- add favicon reference to the calendar index page using the provided icon

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69253320d63c832b99037a6622057939)