### PR TITLE
Add favicon to calendar page

### DIFF
--- a/jofun2/calendar/index.html
+++ b/jofun2/calendar/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Calendario Jofun2</title>
+  <link rel="icon" type="image/png" href="./faviconn.png" />
   <style>
     :root {
       --bg: #f4f6fb;


### PR DESCRIPTION
## Summary
- add a favicon link to the calendar index page pointing to the existing icon file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692534e3775c832b9115f41543bf8c1b)